### PR TITLE
[CA] Update 404 link for VPA architecture docs

### DIFF
--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -199,7 +199,7 @@ kills them so that they can be recreated by their controllers with the updated r
 * [Admission Plugin](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/admission-controller/README.md) - it sets the correct resource requests on new pods (either just created
 or recreated by their controller due to Updater's activity).
 
-More on the architecture can be found [HERE](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/autoscaling/vertical-pod-autoscaler.md).
+More on the architecture can be found [HERE](https://github.com/kubernetes/design-proposals-archive/blob/main/autoscaling/vertical-pod-autoscaler.md).
 
 ### Tear down
 


### PR DESCRIPTION
Update the VPA README to fix a 404 link.

Same as https://github.com/zalando-incubator/autoscaler/pull/99 but in the cluster-autoscaler branch.