### PR TITLE
Prefer volume limits from env var instead of from allocatable resources

### DIFF
--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
@@ -252,10 +252,13 @@ func (pl *nonCSILimits) Filter(ctx context.Context, _ *framework.CycleState, pod
 
 	numNewVolumes := len(newVolumes)
 	maxAttachLimit := pl.maxVolumeFunc(node)
-	volumeLimits := nodeInfo.VolumeLimits()
-	if maxAttachLimitFromAllocatable, ok := volumeLimits[pl.volumeLimitKey]; ok {
-		maxAttachLimit = int(maxAttachLimitFromAllocatable)
-	}
+	// after getting the maximum attachment limit via `maxVolumeFunc`, the following code amends this value
+	// by reading a field on the node object called `attachable-volumes-aws-ebs`. Since we don't want to
+	// rely on that value but cannot remove/change it at the moment, the easiest way is to comment out that code.
+	// volumeLimits := nodeInfo.VolumeLimits()
+	// if maxAttachLimitFromAllocatable, ok := volumeLimits[pl.volumeLimitKey]; ok {
+	// 	maxAttachLimit = int(maxAttachLimitFromAllocatable)
+	// }
 
 	if numExistingVolumes+numNewVolumes > maxAttachLimit {
 		// violates MaxEBSVolumeCount or MaxGCEPDVolumeCount

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
@@ -252,13 +252,10 @@ func (pl *nonCSILimits) Filter(ctx context.Context, _ *framework.CycleState, pod
 
 	numNewVolumes := len(newVolumes)
 	maxAttachLimit := pl.maxVolumeFunc(node)
-	// after getting the maximum attachment limit via `maxVolumeFunc`, the following code amends this value
-	// by reading a field on the node object called `attachable-volumes-aws-ebs`. Since we don't want to
-	// rely on that value but cannot remove/change it at the moment, the easiest way is to comment out that code.
-	// volumeLimits := nodeInfo.VolumeLimits()
-	// if maxAttachLimitFromAllocatable, ok := volumeLimits[pl.volumeLimitKey]; ok {
-	// 	maxAttachLimit = int(maxAttachLimitFromAllocatable)
-	// }
+	volumeLimits := nodeInfo.VolumeLimits()
+	if maxAttachLimitFromAllocatable, ok := volumeLimits[pl.volumeLimitKey]; ok {
+		maxAttachLimit = int(maxAttachLimitFromAllocatable)
+	}
 
 	if numExistingVolumes+numNewVolumes > maxAttachLimit {
 		// violates MaxEBSVolumeCount or MaxGCEPDVolumeCount

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/volume/util/attach_limit.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/volume/util/attach_limit.go
@@ -28,13 +28,13 @@ const (
 	// EBSVolumeLimitKey resource name that will store volume limits for EBS
 	EBSVolumeLimitKey = "attachable-volumes-aws-ebs"
 	// EBSNitroLimitRegex finds nitro instance types with different limit than EBS defaults
-	EBSNitroLimitRegex = "^[cmr]5.*|t3|z1d"
+	EBSNitroLimitRegex = "^[cmr][56].*|t3|z1d"
 	// DefaultMaxEBSVolumes is the limit for volumes attached to an instance.
 	// Amazon recommends no more than 40; the system root volume uses at least one.
 	// See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html#linux-specific-volume-limits
 	DefaultMaxEBSVolumes = 39
 	// DefaultMaxEBSNitroVolumeLimit is default EBS volume limit on m5 and c5 instances
-	DefaultMaxEBSNitroVolumeLimit = 25
+	DefaultMaxEBSNitroVolumeLimit = 22
 	// AzureVolumeLimitKey stores resource name that will store volume limits for Azure
 	AzureVolumeLimitKey = "attachable-volumes-azure-disk"
 	// GCEVolumeLimitKey stores resource name that will store volume limits for GCE node


### PR DESCRIPTION
Volume limits (node allocatable resource called `attachable-volumes-aws-ebs`) are incorrectly set to `25` (and `39` for `m/c/r6` instance types) by a core Kubernetes component. I tried to patch it in the respective components but it didn't yield the expected result. The only component I didn't patch is the `kubelet` (because we don't have a pipeline for it) so I suspect that the functionality is executed there but didn't investigate any futher.

Instead, we can tell CA not to use that field in the first place and solely rely on the passed in ENV variable `KUBE_MAX_PD_VOLS` as we do it [here](https://github.com/zalando-incubator/kubernetes-on-aws/blob/6aa4c029cce2dc545b6383c9074c434de5527b75/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml#L74-L75). The changes in this PR result in exactly that.



