### PR TITLE
ca: build multi arch only

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -42,6 +42,6 @@ pipeline:
 
       docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
       docker buildx build --rm -t "${IMAGE}" --platform linux/amd64,linux/arm64 --push \
-        --build-arg BUILD_FOLDER=build --build-arg BASEIMAGE=container-registry.zalando.net/library/alpine-3.13:latest .
+        --build-arg BUILD_FOLDER=build --build-arg BASEIMAGE=container-registry.zalando.net/library/alpine-3:latest .
 
       cdp-promote-image "${IMAGE}"

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -27,20 +27,6 @@ pipeline:
     cmd: |
       cd cluster-autoscaler
       make test-in-docker
-  - desc: "Build and release"
-    cmd: |
-      if [[ "${CDP_TARGET_BRANCH}" != "zalando-cluster-autoscaler" || -n "${CDP_PULL_REQUEST_NUMBER}" ]]; then
-        VERSION="${VERSION}.dev-${CDP_TARGET_REPOSITORY_COUNTER}"
-      else
-        VERSION="${VERSION}.${CDP_TARGET_BRANCH_COUNTER}"
-      fi
-
-      cd cluster-autoscaler
-      make build-in-docker
-
-      IMAGE="${DOWNSTREAM}:${VERSION}"
-      docker build --build-arg BASEIMAGE=container-registry.zalando.net/library/alpine-3.13:latest --build-arg TARGETARCH= -t "${IMAGE}" .
-      docker push "${IMAGE}"
   - desc: "Build and release (multi-arch)"
     cmd: |
       if [[ "${CDP_TARGET_BRANCH}" != "zalando-cluster-autoscaler" || -n "${CDP_PULL_REQUEST_NUMBER}" ]]; then


### PR DESCRIPTION
* Only build multi-arch image to reduce the time to build.
* Use alpine-3 as base image (instead of the outdated alpine-3.13).