### PR TITLE
ca: Change image tag version to reflect the upstream version it's based on

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -8,7 +8,7 @@ pipeline:
   type: script
   working_dir: /go/src/k8s.io/autoscaler
   env:
-    VERSION: "v1.27.5-internal"
+    VERSION: "v1.18.2-internal"
     DOWNSTREAM: "registry-write.opensource.zalan.do/teapot/kube-cluster-autoscaler"
     TARGET_NAME: "container-registry-test.zalando.net/teapot/kube-cluster-autoscaler"
   commands:


### PR DESCRIPTION
Our fork is still based on the upstream version v1.18.2 of CA, we have just updated client-go libraries to v1.27.12, but this doesn't change the CA version.

Change the version back to reflect this.