### PR TITLE
fix fatal crash when CPU value is not an integer

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_util.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_util.go
@@ -20,14 +20,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"io/ioutil"
-	klog "k8s.io/klog/v2"
 	"net/http"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	klog "k8s.io/klog/v2"
 )
 
 var (
@@ -137,7 +138,13 @@ func parseMemory(memory string) int64 {
 func parseCPU(cpu string) int64 {
 	i, err := strconv.ParseInt(cpu, 10, 64)
 	if err != nil {
-		klog.Fatal(err)
+		// klog.Fatal(err)
+		// invalid CPU values can be treated as 0, this will result in
+		// the instance type being ignored in the autoscaling process
+		klog.Warningf("Invalid CPU value '%s', treating as 0", cpu)
+		// Returning 0 instead of logging fatal to avoid crashing the autoscaler
+		// This allows the autoscaler to continue functioning even if some instance types have invalid CPU
+		return 0
 	}
 	return i
 }


### PR DESCRIPTION
We have the autoscaler crashing in production as the pricing API is returning fraction values for VCPU attributes of some instance type.

```
I0730 09:05:51.150821       1 main.go:398] Cluster Autoscaler 1.18.2
I0730 09:05:51.315574       1 leaderelection.go:245] attempting to acquire leader lease kube-system/cluster-autoscaler...
I0730 09:06:09.237303       1 leaderelection.go:255] successfully acquired lease kube-system/cluster-autoscaler
I0730 09:06:09.250644       1 cloud_provider_builder.go:29] Building aws cloud provider.
I0730 09:06:09.250708       1 aws_util.go:68] fetching https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/eu-central-1/index.json
F0730 09:06:14.270398       1 aws_util.go:140] strconv.ParseInt: parsing "0.125": invalid syntax
```

This quick fix simply returns `0` in this case, causing the instance type to be excluded from autoscaling decisions.